### PR TITLE
Make progress bar work in pytho3 with size >= 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ def log_progress(sequence, every=None, size=None):
             if size <= 200:
                 every = 1
             else:
-                every = size / 200     # every 0.5%
+                every = int(size / 200)     # every 0.5%
     else:
         assert every is not None, 'sequence is iterator, set every'
 


### PR DESCRIPTION
It seems that in python3/jupyter size / 200 comes out as a float
and as a result the index % every logic doesn't work. We can simply
cast the size / 200 to int to solve the issue